### PR TITLE
Issue No. #44 [BUG FIXED] In the footer section, the copyright year should be dynamically generated instead of being statically hardcoded.

### DIFF
--- a/copyrightYear.js
+++ b/copyrightYear.js
@@ -1,0 +1,4 @@
+let copyRightYear = document.getElementById("copyright-year");
+let currentDate = new Date();
+let currentYear = currentDate.getFullYear();
+copyRightYear.innerText = currentYear;

--- a/index.html
+++ b/index.html
@@ -1047,12 +1047,13 @@
             </div>
             <br /><br />
             <hr class="one" />
-            <p class="copyright">&copy; 2023 Codess.Cafe, All Right Reserved</p>
+            <p class="copyright">&copy; <span id="copyright-year"></span> Codess.Cafe, All Right Reserved</p>
           </div>
         </footer>
       </div>
     </section>
-
+<!-- copyright-year Script -->
+<script src="./copyrightYear.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/linkedin.html
+++ b/linkedin.html
@@ -129,10 +129,12 @@
             </div>
             <br><br>
             <hr class="one">
-            <p class="copyright">&copy; 2023 Codess.Cafe, All Right Reserved</p>
+            <p class="copyright">&copy; <span id="copyright-year"></span> Codess.Cafe, All Right Reserved</p>
          </div>
       </footer>
    </div>
+   <!-- copyright-year Script -->
+   <script src="./copyrightYear.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>
 

--- a/medium.html
+++ b/medium.html
@@ -131,10 +131,12 @@
             </div>
             <br><br>
             <hr class="one">
-            <p class="copyright">&copy; 2023 Codess.Cafe, All Right Reserved</p>
+            <p class="copyright">&copy; <span id="copyright-year"></span> Codess.Cafe, All Right Reserved</p>
          </div>
       </footer>
    </div>
+   <!-- copyright-year Script -->
+   <script src="./copyrightYear.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>
 

--- a/mentors.html
+++ b/mentors.html
@@ -768,10 +768,12 @@
             </div>
             <br /><br />
             <hr class="one" />
-            <p class="copyright">&copy; 2023 Codess.Cafe, All Right Reserved</p>
+            <p class="copyright">&copy; <span id="copyright-year"></span> Codess.Cafe, All Right Reserved</p>
           </div>
         </footer>
       </div>
+      <!-- copyright-year Script -->
+     <script src="./copyrightYear.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>
     </section>

--- a/twitter.html
+++ b/twitter.html
@@ -131,10 +131,12 @@
             </div>
             <br><br>
             <hr class="one">
-            <p class="copyright">&copy; 2023 Codess.Cafe, All Right Reserved</p>
+            <p class="copyright">&copy; <span id="copyright-year"></span> Codess.Cafe, All Right Reserved</p>
          </div>
       </footer>
    </div>
+   <!-- copyright-year Script -->
+   <script src="./copyrightYear.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>
 

--- a/youtube.html
+++ b/youtube.html
@@ -130,10 +130,12 @@
                </div>
                <br><br>
                <hr class="one">
-               <p class="copyright">&copy; 2023 Codess.Cafe, All Right Reserved</p>
+               <p class="copyright">&copy; <span id="copyright-year"></span> Codess.Cafe, All Right Reserved</p>
             </div>
          </footer>
       </div>
+      <!-- copyright-year Script -->
+     <script src="./copyrightYear.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>
 


### PR DESCRIPTION
Closes #44 