### PR TITLE
Basic changes to mentors page

### DIFF
--- a/mentors.html
+++ b/mentors.html
@@ -12,6 +12,16 @@
       integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
       crossorigin="anonymous"
     />
+    <!-----------------------w3-CSS------------------------------------->
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css" />
+    <link rel="stylesheet" href="w3.css" />
+
+    <!------------fontawesome cdn----------------->
+    <script
+      src="https://kit.fontawesome.com/61024fa0a4.js"
+      crossorigin="anonymous"
+    ></script>
+
     <!--Custom CSS-->
     <link rel="stylesheet" href="style.css" />
     <link rel="stylesheet" href="custom.css" />
@@ -123,7 +133,8 @@
         <ul>
           <li>
             <a href="twitter.html"
-              >Twitter <i class="fa-brands fa-x-twitter social_icons"></i></a>
+              >Twitter <i class="fa-brands fa-x-twitter social_icons"></i
+            ></a>
           </li>
           <li>
             <a href="linkedin.html"
@@ -150,29 +161,40 @@
             <h1 class="display-6 text-center font-weight-bold">Our Team</h1>
             <hr class="one" />
           </div>
-          
-          <h1 class="display-6 text-center font-weight-bold">Sophomore Mentors</h1>
+
+          <h1 class="display-6 text-center font-weight-bold">
+            Mentors
+          </h1>
           <!-- mentors -->
           <div class="row">
+            <!-- senior mentors -->
+            <br /><br />
+            <div class="col-12 mb-5">
+              <hr class="one" />
+              <h1 class="display-6 text-center font-weight-bold">
+                Senior Mentors
+              </h1>
+            </div>
             <div class="col-lg-4 col-md-6 mentor-cards-home">
               <div class="card">
-                <div class="img-bx" style="display: flex">
-                  <img src="images/mentor/37.jpeg" alt="img" />
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/6.jpg" alt="Your Image" />
                 </div>
                 <div class="content">
-                  <div class="detail">
+                  <div class="detail" id="new-mentors">
                     <h2>
-                        Ankita Jain<br /><h2
-                        >MCE ,DTU</h2
-                      >
+                      Aeshna Jain<br />
+                      <h2>SDE: Uber<br />IT, IGDTUW</h2>
                     </h2>
-                    <ul class="sci">
-                      <li>
-                        <a href="#"
-                          ><i class="fa fa-linkedin linkedin-in"></i
-                        ></a>
-                      </li>
-                    </ul>
                   </div>
                 </div>
               </div>
@@ -180,23 +202,24 @@
 
             <div class="col-lg-4 col-md-6 mentor-cards-home">
               <div class="card">
-                <div class="img-bx" style="display: flex">
-                  <img src="images/mentor/31.jpeg" alt="img" />
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/0.jpg" alt="Your Image" />
                 </div>
                 <div class="content">
-                  <div class="detail">
+                  <div class="detail" id="new-mentors">
                     <h2>
-                        Anshika Jain<br /><h2
-                        >CSE,DTU</h2
-                      >
+                      Aiman Siddiqua<br />
+                      <h2>SDE Intern: Amazon<br />MCE, DTU</h2>
                     </h2>
-                    <ul class="sci">
-                      <li>
-                        <a href="#"
-                          ><i class="fa fa-linkedin linkedin-in"></i
-                        ></a>
-                      </li>
-                    </ul>
                   </div>
                 </div>
               </div>
@@ -204,23 +227,24 @@
 
             <div class="col-lg-4 col-md-6 mentor-cards-home">
               <div class="card">
-                <div class="img-bx" style="display: flex">
-                  <img src="images/mentor/20.jpeg" alt="img" />
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/2.jpg" alt="Your Image" />
                 </div>
                 <div class="content">
-                  <div class="detail">
+                  <div class="detail" id="new-mentors">
                     <h2>
-                        Apeksha Manchanda<br /><h2
-                        >SDE Intern: Google<br />CSE, IGDTUW</h2
-                      >
+                      Akanksha Tanwar<br />
+                      <h2>SDE Intern: Microsoft<br />IT, DTU</h2>
                     </h2>
-                    <ul class="sci">
-                      <li>
-                        <a href="#"
-                          ><i class="fa fa-linkedin linkedin-in"></i
-                        ></a>
-                      </li>
-                    </ul>
                   </div>
                 </div>
               </div>
@@ -228,509 +252,529 @@
 
             <div class="col-lg-4 col-md-6 mentor-cards-home">
               <div class="card">
-                <div class="img-bx" style="display: flex">
-                  <img src="images/mentor/35.jpeg" alt="img" />
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/37.jpeg" alt="Your Image" />
                 </div>
                 <div class="content">
-                  <div class="detail">
+                  <div class="detail" id="new-mentors">
                     <h2>
-                        Eesha Yadav<br /><h2
-                        >SDE Intern: Google<br />ECE, IIT Dhanbad</h2
-                      >
+                      Ankita Jain<br />
+                      <h2>MCE ,DTU</h2>
                     </h2>
-                    <ul class="sci">
-                      <li>
-                        <a href="#"
-                          ><i class="fa fa-linkedin linkedin-in"></i
-                        ></a>
-                      </li>
-                    </ul>
                   </div>
                 </div>
               </div>
             </div>
+
             <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/30.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Ishita Mundhra<br /><h2
-                          >SDE Intern: Amazon<br />IT, Jadhav University</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/31.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Anshika Jain<br />
+                      <h2>CSE,DTU</h2>
+                    </h2>
                   </div>
                 </div>
               </div>
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/21.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Kaushiki Raj<br /><h2
-                          >SDE Intern: Microsoft<br />MCA, BITS Mesra</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/22.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Manasvi Singh<br /><h2
-                          >SDE Intern: Microsoft<br />CS & AI, IIITD</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/23.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Navya Singla<br /><h2
-                          >SDE Intern: Flipkart<br />CSE, DTU</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/33.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Neha Goyal<br /><h2
-                          >Step Intern: Google<br />CSE, DTU</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/36.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Pranitha Sridhar<br /><h2
-                          >EE, IIT Dhanbad</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/24.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Tanushree Bhattacharya<br /><h2
-                          >SDE Intern: Microsoft<br />ECE, NIT Durgapur</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
+            </div>
 
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/34.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Tanvy Bhola<br /><h2
-                          >CSE, AIT Pune</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/20.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Apeksha Manchanda<br />
+                      <h2>SDE Intern: Google<br />CSE, IGDTUW</h2>
+                    </h2>
                   </div>
                 </div>
               </div>
+            </div>
 
-              <div class="col-lg-4 col-md-6 mentor-cards-home">
-                <div class="card">
-                  <div class="img-bx" style="display: flex">
-                    <img src="images/mentor/32.jpeg" alt="img" />
-                  </div>
-                  <div class="content">
-                    <div class="detail">
-                      <h2>
-                        Vanshika Gupta<br /><h2
-                          >Step Intern: Google<br />CSE, DTU</h2
-                        >
-                      </h2>
-                      <ul class="sci">
-                       
-                        <li>
-                          <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                          
-                        </li>
-                      </ul>
-                    </div>
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/1.jpg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Chitra Singla<br />
+                      <h2>SDE Intern: Amazon<br />CSE, DTU</h2>
+                    </h2>
                   </div>
                 </div>
               </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/9.jpg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Deepti Aggarwal<br />
+                      <h2>SDE: Microsoft<br />CSE, DTU</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/35.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Eesha Yadav<br />
+                      <h2>SDE Intern: Google<br />ECE, IIT Dhanbad</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/30.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Ishita Mundhra<br />
+                      <h2>SDE Intern: Amazon<br />IT, Jadhav University</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/4.jpg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Joshika<br />
+                      <h2>SDE: Salesforce<br />CSE, IIT Patna</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/28.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Kajal Gupta<br />
+                      <h2>SDE Intern: Uber<br />CSE, DTU</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/21.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Kaushiki Raj<br />
+                      <h2>SDE Intern: Microsoft<br />MCA, BITS Mesra</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/7.jpg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Krati Garg<br />
+                      <h2>SDE Intern: Google<br />CSE, DTU</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/22.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Manasvi Singh<br />
+                      <h2>SDE Intern: Microsoft<br />CS & AI, IIITD</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/23.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Navya Singla<br />
+                      <h2>SDE Intern: Flipkart<br />CSE, DTU</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/33.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Neha Goyal<br />
+                      <h2>Step Intern: Google<br />CSE, DTU</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/17.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Nishee Sharma<br />
+                      <h2>SDE Intern: Google & Uber<br />MCA, IIT Dhanbad</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/29.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Parigya Jain<br />
+                      <h2>SDE Intern: Amazon<br />MCA, DTU</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/36.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Pranitha Sridhar<br />
+                      <h2>EE, IIT Dhanbad</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/19.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Priyanka Yadav<br />
+                      <h2>SDE: LinkedIn<br />CSE, UPES</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/24.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Tanushree Bhattacharya<br />
+                      <h2>SDE Intern: Microsoft<br />ECE, NIT Durgapur</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/34.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Tanvy Bhola<br />
+                      <h2>CSE, AIT Pune</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6 mentor-cards-home">
+              <div class="card">
+                <ul class="social-icons">
+                  <li>
+                    <a
+                      href="https://www.linkedin.com/in/subhanshi-rawat/"
+                      target="_blank"
+                      ><i class="fab fa-linkedin"></i
+                    ></a>
+                  </li>
+                </ul>
+                <div class="circle-mentors">
+                  <img src="images/mentor/32.jpeg" alt="Your Image" />
+                </div>
+                <div class="content">
+                  <div class="detail" id="new-mentors">
+                    <h2>
+                      Vanshika Gupta<br />
+                      <h2>Step Intern: Google<br />CSE, DTU</h2>
+                    </h2>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-         
-          <!-- senior mentors -->
-          <br/><br/>
-          <div class="col-12 mb-5">
-            
-            <hr class="one" />
-            <h1 class="display-6 text-center font-weight-bold">Senior Mentors</h1>
-          </div>
-                    <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/6.jpg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Aeshna Jain<br /><h2
-                                  >SDE: Uber<br />IT, IGDTUW</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/0.jpg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Aiman Siddiqua<br /><h2
-                                  >SDE Intern: Amazon<br />MCE, DTU</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/2.jpg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Akanksha Tanwar<br /><h2
-                                  >SDE Intern: Microsoft<br />IT, DTU</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/1.jpg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Chitra Singla<br /><h2
-                                  >SDE Intern: Amazon<br />CSE, DTU</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/9.jpg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Deepti Aggarwal<br /><h2
-                                  >SDE: Microsoft<br />CSE, DTU</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/4.jpg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Joshika<br /><h2
-                                  >SDE: Salesforce<br />CSE, IIT Patna</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/28.jpeg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Kajal Gupt<br /><h2
-                                  >SDE Intern: Uber<br />CSE, DTU</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/7.jpg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Krati Garg<br /><h2
-                                  >SDE Intern: Google<br />CSE, DTU</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/17.jpeg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Nishee Sharma<br /><h2
-                                  >SDE Intern: Google & Uber<br />MCA, IIT Dhanbad</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/29.jpeg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Parigya Jain<br /><h2
-                                  >SDE Intern: Amazon<br />MCA, DTU</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="col-lg-4 col-md-6 mentor-cards-home">
-                        <div class="card">
-                          <div class="img-bx" style="display: flex">
-                            <img src="images/mentor/19.jpeg" alt="img" />
-                          </div>
-                          <div class="content">
-                            <div class="detail">
-                              <h2>
-                                Priyanka Yadav<br /><h2
-                                  >SDE: LinkedIn<br />CSE, UPES</h2
-                                >
-                              </h2>
-                              <ul class="sci">
-                               
-                                <li>
-                                  <a href="#"><i class="fa fa-linkedin linkedin-in"></i></a>
-                                  
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                </div>
         </div>
       </div>
 
@@ -768,12 +812,15 @@
             </div>
             <br /><br />
             <hr class="one" />
-            <p class="copyright">&copy; <span id="copyright-year"></span> Codess.Cafe, All Right Reserved</p>
+            <p class="copyright">
+              &copy; <span id="copyright-year"></span> Codess.Cafe, All Right
+              Reserved
+            </p>
           </div>
         </footer>
       </div>
       <!-- copyright-year Script -->
-     <script src="./copyrightYear.js"></script>
+      <script src="./copyrightYear.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>
     </section>

--- a/style.css
+++ b/style.css
@@ -589,6 +589,10 @@ body {
   font-weight: 500;
 }
 
+#new-mentors{
+  margin-bottom: 20px;
+}
+
 .sci {
   position: relative;
   display: flex;


### PR DESCRIPTION
The following changes have been made:

1. Have imported / copied the relevant links from the index.html page for correct rendering of fonts and icons as expected.

2. Have moved all the sophomore mentors to the senior section.

3. Have formatted all the cards according to the "Meet the Team" section cards as requested.

4. I have added some changes to the style.css file for correct positioning of the text. It can be improved still as the space between the name and the role is quite large and I didn't have time to figure out why such a change happened on this page as it was okay in the main page.

5. For whoever is taking over, the LinkedIn links for all the cards need to be found and pasted. Currently all the cards have a LinkedIn link of one of the team members card which I copy pasted.

6. I haven't touched the Excel sheet yet so that part has to be done from scratch. 